### PR TITLE
Update slideNormalize.cpp to use TCLAP

### DIFF
--- a/source/slideNormalize.cpp
+++ b/source/slideNormalize.cpp
@@ -7,98 +7,100 @@
 #include <string>
 #include <tclap/CmdLine.h>
 
-using namespace std;
-
-void print_help()  {
-
-	cout << "slideNormalize: Normalize an image by assessing the image texture using OpenCV's CLAHE (Contrast Limited Adaptive Histogram Equalization). " << endl << endl << "usage" << endl << "  slideNormalize <filename> " << endl;
-// 	cout << "  -c/--cp/--cellprofiler: " << endl << "\t Whether to prepare the image for CellProfiler (save as bmp instead of png, and prepend \"ENTROPY_\" to the filename), default 'false'" << endl << endl;
-	cout << "description" << endl;
-	cout << "  slideNormalize normalizes an image by assessing image texture using OpenCV's CLAHE (Contrast Limited Adaptive Histogram Equalization). " << endl << endl;
-	cout << "slideNormalize was written by Tim Bezemer, and edited by Sander W. van der Laan. For questions/comments please contact s.w.vanderlaan@gmail.com" << endl << endl;
-// 	cout << "slideEMask uses the CImg library, released under the CeCILL license" << endl;
-}
-
-// commandline arguments, where the output filename is optional
-// int main(int argc,char **argv) 
-// {
-// 	TCLAP::CmdLine cmd("slideNormalize: normalizes an image by assessing image texture using OpenCV's CLAHE (Contrast Limited Adaptive Histogram Equalization)", ' ', "0.9");
-// 
-// 	TCLAP::ValueArg<std::string> filenameArg("f","file","The filename of the NDPI/TIF file to process.", true, "", "string", cmd);
-// 	TCLAP::ValueArg<std::string> outnameArg("o","out","The output-filename of the NDPI/TIF file to process.", false, "", "string", cmd);
-// 	TCLAP::ValueArg<std::string> extnameArg("e","ext","The standard output-filename extension of the image-tile to process.", false, "", "string", cmd);
-// 
-// 	cmd.parse( argc, argv );
-// 
-// 	std::string filename = filenameArg.getValue();
-// 	
-// }
-
-
-bool is_file_exist(const char *fileName)
-{
-	std::ifstream infile(fileName);
-	return infile.good();
+bool is_file_exist(std::string & fileName) {
+    std::ifstream infile(fileName);
+    return infile.good();
 }
 
 std::string replaceString(std::string subject, const std::string& search,
-						  const std::string& replace) {
-	size_t pos = 0;
-	while((pos = subject.find(search, pos)) != std::string::npos) {
-		 subject.replace(pos, search.length(), replace);
-		 pos += replace.length();
-	}
-	return subject;
+                          const std::string& replace) {
+    size_t pos = 0;
+    while((pos = subject.find(search, pos)) != std::string::npos) {
+         subject.replace(pos, search.length(), replace);
+         pos += replace.length();
+    }
+    return subject;
 }
 
-int main(int argc, char** argv)
-{
+std::string remove_extension(const std::string& filename) {
+    size_t lastdot = filename.find_last_of(".");
+    if (lastdot == std::string::npos) return filename;
+    return filename.substr(0, lastdot); 
+}
 
-	if (is_file_exist(argv[1]) == false) {
-	  cout << "Creating normalized image for file: " << argv[1] << endl;
-	  std::cout << "ERROR: File not found." << std::endl;
-	  exit(1);
+void normalize_slide_image(std::string & input_filename, std::string & output_filename, bool show = false) {
+    // READ RGB color image and convert it to Lab
+    // add in verbose comments processing
+    cv::Mat bgr_image = cv::imread(input_filename);
+    cv::Mat lab_image;
+    cv::cvtColor(bgr_image, lab_image, CV_BGR2Lab);
 
-	}
+    // Extract the L channel
+    std::vector<cv::Mat> lab_planes(3);
+    cv::split(lab_image, lab_planes);  // now we have the L image in lab_planes[0]
 
-	// READ RGB color image and convert it to Lab
-	// add in verbose comments processing
-	// cout << "Creating normalized image for file: " << argv[1] << endl;
-	cv::Mat bgr_image = cv::imread(argv[1]);
-	cv::Mat lab_image;
-	cv::cvtColor(bgr_image, lab_image, CV_BGR2Lab);
+    // apply the CLAHE algorithm to the L channel
+    cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE();
+    clahe->setClipLimit(2);
+    cv::Mat dst;
+    clahe->apply(lab_planes[0], dst);
 
-	// Extract the L channel
-	std::vector<cv::Mat> lab_planes(3);
-	cv::split(lab_image, lab_planes);  // now we have the L image in lab_planes[0]
-
-	// apply the CLAHE algorithm to the L channel
-	cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE();
-	clahe->setClipLimit(2);
-	cv::Mat dst;
-	clahe->apply(lab_planes[0], dst);
-
-	// Merge the the color planes back into an Lab image
-	dst.copyTo(lab_planes[0]);
-	cv::merge(lab_planes, lab_image);
+    // Merge the the color planes back into an Lab image
+    dst.copyTo(lab_planes[0]);
+    cv::merge(lab_planes, lab_image);
 
    // convert back to RGB
    cv::Mat image_clahe;
    cv::cvtColor(lab_image, image_clahe, CV_Lab2BGR);
 
    // display the results  (you might also want to see lab_planes[0] before and after).
-   //cv::imshow("image original", bgr_image);
-   //cv::imshow("image CLAHE", image_clahe);
-   //cv::waitKey();
+   if (show) {
+       std::cout << "Press any key to quit..." << std::endl;
+       cv::imshow("image original", bgr_image);
+       cv::imshow("image CLAHE", image_clahe);
+       cv::waitKey();
+   }
 
-// OPTIONAL: Make sure that you can control the extension name
-   std::string new_filename = replaceString( std::string(argv[1]), ".tile.tissue.png", ".normalized.tile.tissue.png" );
+   cv::imwrite(output_filename, image_clahe);
+}
 
-// Make sure that  if an output file name is given, it will output the file appropriately
-//    if (argv[2] == true) {
-//      cout << "Saving normalized image as " << argv[2] << endl;
-//      std::string new_filename = std::string(argv[2]);
-//    }
-   
-   cv::imwrite(new_filename, image_clahe);
+int main(int argc,char **argv) {
+    TCLAP::CmdLine cmd("slideNormalize: normalizes an image by assessing image texture using OpenCV's CLAHE (Contrast Limited Adaptive Histogram Equalization)", ' ', "0.9");
+
+    TCLAP::ValueArg<std::string> filenameArg("f","file","The filename of the NDPI/TIF file to process.", true, "", "string", cmd);
+    TCLAP::ValueArg<std::string> outnameArg("o","out","The output-filename of the NDPI/TIF file to process.", false, "", "string", cmd);
+    TCLAP::ValueArg<std::string> extnameArg("e","ext","The standard output-filename extension of the image-tile to process.", false, "", "string", cmd);
+    TCLAP::SwitchArg showArg("s","show","Show results in a graphical interface", cmd, false);
+
+    cmd.parse(argc, argv);
+
+    std::string inname = filenameArg.getValue();
+    std::string extname = extnameArg.getValue();
+    std::string outname = outnameArg.getValue();
+    bool show = showArg.getValue();
+
+    if (outname.size() == 0) {
+       outname = replaceString(inname, ".tile.tissue.png", ".normalized.tile.tissue.png" );
+    }
+
+    if (extname.size() != 0) {
+        outname = remove_extension(outname) + "." + extname;
+    }
+
+    if (!is_file_exist(inname)) {
+        std::cout << "Creating normalized image for file: " << inname << std::endl;
+        std::cout << "ERROR: File not found." << std::endl;
+        exit(1);
+    }
+
+    if (inname == outname) {
+        std::cout << "Creating normalized image for file: " << inname << std::endl;
+      std::cout << "ERROR: Refusing to overwrite sourcefile with output" << std::endl;
+      exit(1);
+    }
+
+    std::cout << "input:  " << inname << std::endl;
+    std::cout << "output: " << outname << std::endl;
+
+    normalize_slide_image(inname, outname, show);
 }


### PR DESCRIPTION
```
USAGE:

   ./slideNormalize  [-s] [-e <string>] [-o <string>] -f <string> [--]
                     [--version] [-h]


Where:

   -s,  --show
     Show results in graphical interface

   -e <string>,  --ext <string>
     The standard output-filename extension of the image-tile to process.

   -o <string>,  --out <string>
     The output-filename of the NDPI/TIF file to process.

   -f <string>,  --file <string>
     (required)  The filename of the NDPI/TIF file to process.

   --,  --ignore_rest
     Ignores the rest of the labeled arguments following this flag.

   --version
     Displays version information and exits.

   -h,  --help
     Displays usage information and exits.


   slideNormalize: normalizes an image by assessing image texture using
   OpenCV's CLAHE (Contrast Limited Adaptive Histogram Equalization)
```